### PR TITLE
Added travis configuration for auto builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+services: docker
+env:
+  DOCKER_COMPOSE_VERSION: 1.6.2
+before_install:
+  # Upgrade docker/docker-compose versions so we can use v2 of the Dockerfile format
+  - docker -v
+  - sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=1.10.3-0~trusty
+  - docker -v
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m`" > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  # set env vars in the build settings to interact with repositories
+  # see https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
+  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+script:
+  - docker build -t "${DOCKER_REPO}:${TRAVIS_TAG}" .
+deploy:
+  provider: script
+  api_key: "$GITHUB_API_TOKEN"
+  script: docker push "${DOCKER_REPO}:${TRAVIS_TAG}"
+  skip_cleanup: false
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
   - docker build -t "${DOCKER_REPO}:${TRAVIS_TAG}" .
 deploy:
   provider: script
-  api_key: "$GITHUB_API_TOKEN"
   script: docker push "${DOCKER_REPO}:${TRAVIS_TAG}"
   skip_cleanup: false
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ before_install:
   # see https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 script:
-  - docker build -t "${DOCKER_REPO}:${TRAVIS_TAG}" .
+  - docker build -t "zopanix/factorio:${TRAVIS_TAG}" .
 deploy:
   provider: script
-  script: docker push "${DOCKER_REPO}:${TRAVIS_TAG}"
+  script: docker push "zopanix/factorio:${TRAVIS_TAG}"
   skip_cleanup: false
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,5 @@
 services: docker
-env:
-  DOCKER_COMPOSE_VERSION: 1.6.2
 before_install:
-  # Upgrade docker/docker-compose versions so we can use v2 of the Dockerfile format
-  - docker -v
-  - sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=1.10.3-0~trusty
-  - docker -v
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m`" > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   # set env vars in the build settings to interact with repositories
   # see https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
- Added travis configuration

Travis-CI is free for public repos.  To setup travis, go to https://travis-ci.org and add this repository.  Go to the settings within that repository and [set the following environment variables](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings):
- `DOCKER_EMAIL`
- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`

These environment variables enable Travis-CI to login to docker... the user should have write permissions to the repo.  The below segment is executed if all other steps pass successfully.  This process will not run in the event of any kind of terminating failure (such as failure to `docker build`).   The travis-ci process gets run at every pull request and/or push (depending on how you configure the repo) this section is only executed when a new github release is made.  This means creating a new Release will trigger the CI build process and will eventually get pushed to DockerHub.

```
deploy:
  provider: script
  script: docker push "${DOCKER_REPO}:${TRAVIS_TAG}"
  skip_cleanup: false
  on:
    tags: true
```
