### PR TITLE
Factorio Docker Image moved recently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# THIS IS DEPRECATED please use https://hub.docker.com/r/dtandersen/factorio/
+# THIS IS DEPRECATED please use https://hub.docker.com/r/factoriotools/factorio/
 
 Factorio [![Build Status](https://travis-ci.org/zopanix/docker_factorio_server.svg?branch=master)](https://travis-ci.org/zopanix/docker_factorio_server)  [![Docker Pulls](https://img.shields.io/docker/pulls/zopanix/factorio.svg?maxAge=2592000)](https://hub.docker.com/r/zopanix/factorio/)
 ===== 


### PR DESCRIPTION
The Image moved recently and the new place is here https://hub.docker.com/r/factoriotools/factorio/ .